### PR TITLE
Bump datastore library to latest stable and clean up code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,28 @@ All modules are licensed under [Apache License 2.0](http://www.apache.org/licens
 ## Usage
 
 ### Maven dependencies
-
 ```xml
 <dependency>
     <groupId>com.bobkevic.jackson.datatype</groupId>
     <artifactId>jackson-module-datastore</artifactId>
 </dependency>
 ```
+**_Note that you also need to depend on the jsr310 module_**
+
+```xml
+<dependency>
+    <groupId>com.fasterxml.jackson.datatype</groupId>
+    <artifactId>jackson-datatype-jsr310</artifactId>
+</dependency>
+```
+
 
 ### Registering modules
-
+**_Note that the JavaTimeModule is also added_**
 ```java
 final ObjectMapper mapper = new ObjectMapper()
-   .registerModule(new DatastoreModule());
+   .registerModule(new DatastoreModule())
+   .registerModule(new JavaTimeModule());
 ```
 
 or, alternatively, you can also auto-discover these modules with:

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <jackson-databind.version>2.8.9</jackson-databind.version>
+        <google-cloud-datastore.version>1.5.1</google-cloud-datastore.version>
     </properties>
 
     <dependencies>
@@ -48,7 +49,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-datastore</artifactId>
-            <version>0.8.1-beta</version>
+            <version>${google-cloud-datastore.version}</version>
         </dependency>
 
         <dependency>
@@ -65,12 +66,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>22.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/bobkevic/jackson/datatype/Caster.java
+++ b/src/main/java/com/bobkevic/jackson/datatype/Caster.java
@@ -1,0 +1,29 @@
+package com.bobkevic.jackson.datatype;
+
+/*-
+ * #%L
+ * jackson-datatype-datastore
+ * %%
+ * Copyright (C) 2017 Ilja Bobkevic
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public class Caster {
+
+  @SuppressWarnings("unchecked")
+  public static <T> T cast(final Object object) {
+    return (T) object;
+  }
+}

--- a/src/main/java/com/bobkevic/jackson/datatype/deserializers/FullEntityDeserializer.java
+++ b/src/main/java/com/bobkevic/jackson/datatype/deserializers/FullEntityDeserializer.java
@@ -20,6 +20,8 @@ package com.bobkevic.jackson.datatype.deserializers;
  * #L%
  */
 
+import static com.bobkevic.jackson.datatype.Caster.cast;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -54,6 +56,6 @@ class FullEntityDeserializer extends StdDeserializer<FullEntity> {
     final JsonDeserializer<Object> deserializer =
         ctxt.findContextualValueDeserializer(type, null);
 
-    return mapToFullEntity((Map<String, Value<?>>) deserializer.deserialize(p, ctxt));
+    return mapToFullEntity(cast(deserializer.deserialize(p, ctxt)));
   }
 }

--- a/src/main/java/com/bobkevic/jackson/datatype/deserializers/FullEntityDeserializer.java
+++ b/src/main/java/com/bobkevic/jackson/datatype/deserializers/FullEntityDeserializer.java
@@ -50,7 +50,7 @@ class FullEntityDeserializer extends StdDeserializer<FullEntity> {
 
   @Override
   public FullEntity deserialize(JsonParser p, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+      throws IOException {
     final MapType type =
         ctxt.getTypeFactory().constructMapType(Map.class, String.class, Value.class);
     final JsonDeserializer<Object> deserializer =

--- a/src/main/java/com/bobkevic/jackson/datatype/deserializers/ValueDeserializer.java
+++ b/src/main/java/com/bobkevic/jackson/datatype/deserializers/ValueDeserializer.java
@@ -20,6 +20,7 @@ package com.bobkevic.jackson.datatype.deserializers;
  * #L%
  */
 
+import static com.bobkevic.jackson.datatype.Caster.cast;
 import static com.google.cloud.datastore.DateTime.copyFrom;
 import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toList;
@@ -96,11 +97,11 @@ class ValueDeserializer extends ReferenceTypeDeserializer<Value<?>> {
 
     final Class<?> clazz = contents.getClass();
     if (FullEntity.class.isAssignableFrom(clazz)) {
-      return EntityValue.of((FullEntity<?>) contents);
+      return EntityValue.of(cast(contents));
     } else if (Boolean.class.isAssignableFrom(clazz)) {
-      return BooleanValue.of((Boolean) contents);
+      return BooleanValue.of(cast(contents));
     } else if (Double.class.isAssignableFrom(clazz)) {
-      return DoubleValue.of((Double) contents);
+      return DoubleValue.of(cast(contents));
     } else if (Long.class.isAssignableFrom(clazz) || Integer.class.isAssignableFrom(clazz)) {
       return LongValue.of(Long.valueOf(contents.toString()));
     } else if (String.class.isAssignableFrom(clazz)) {
@@ -113,23 +114,22 @@ class ValueDeserializer extends ReferenceTypeDeserializer<Value<?>> {
                   .setExcludeFromIndexes(value.getBytes().length > 1500)
                   .build());
     } else if (ZonedDateTime.class.isAssignableFrom(clazz)) {
-      final ZonedDateTime dateTime = (ZonedDateTime) contents;
+      final ZonedDateTime dateTime = cast(contents);
       return DateTimeValue.of(DateTime.copyFrom(Date.from(dateTime.toInstant())));
     } else if (Instant.class.isAssignableFrom(clazz)) {
-      final Instant instant = (Instant) contents;
-      return DateTimeValue.of(DateTime.copyFrom(Date.from(instant)));
+      return DateTimeValue.of(DateTime.copyFrom(Date.from(cast(contents))));
     } else if (List.class.isAssignableFrom(clazz)) {
-      final List<Object> rawList = (List<Object>) contents;
+      final List<Object> rawList = cast(contents);
       return ListValue.of(rawList.stream()
           .map(this::referenceValue)
           .collect(toList()));
     } else if (Map.class.isAssignableFrom(clazz)) {
-      final Map<String, Object> rawMap = (Map<String, Object>) contents;
+      final Map<String, Object> rawMap = cast(contents);
       final FullEntity.Builder<IncompleteKey> builder = FullEntity.newBuilder();
       rawMap.forEach((key, value) -> builder.set(key, referenceValue(value)));
       return EntityValue.of(builder.build());
     }
 
-    return (Value<?>) contents;
+    return cast(contents);
   }
 }

--- a/src/main/java/com/bobkevic/jackson/datatype/deserializers/ValueDeserializer.java
+++ b/src/main/java/com/bobkevic/jackson/datatype/deserializers/ValueDeserializer.java
@@ -21,7 +21,6 @@ package com.bobkevic.jackson.datatype.deserializers;
  */
 
 import static com.bobkevic.jackson.datatype.Caster.cast;
-import static com.google.cloud.datastore.DateTime.copyFrom;
 import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toList;
 
@@ -30,9 +29,8 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.deser.std.ReferenceTypeDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.google.cloud.Timestamp;
 import com.google.cloud.datastore.BooleanValue;
-import com.google.cloud.datastore.DateTime;
-import com.google.cloud.datastore.DateTimeValue;
 import com.google.cloud.datastore.DoubleValue;
 import com.google.cloud.datastore.EntityValue;
 import com.google.cloud.datastore.FullEntity;
@@ -41,6 +39,7 @@ import com.google.cloud.datastore.ListValue;
 import com.google.cloud.datastore.LongValue;
 import com.google.cloud.datastore.NullValue;
 import com.google.cloud.datastore.StringValue;
+import com.google.cloud.datastore.TimestampValue;
 import com.google.cloud.datastore.Value;
 import java.sql.Date;
 import java.time.Instant;
@@ -73,8 +72,8 @@ class ValueDeserializer extends ReferenceTypeDeserializer<Value<?>> {
     return Optional.empty();
   }
 
-  static Value dateTimeValueOf(final ZonedDateTime dateTime) {
-    return DateTimeValue.of(copyFrom((Date.from(dateTime.toInstant()))));
+  static Value timeStampValueOf(final ZonedDateTime dateTime) {
+    return TimestampValue.of(Timestamp.of(Date.from(dateTime.toInstant())));
   }
 
   @Override
@@ -108,16 +107,15 @@ class ValueDeserializer extends ReferenceTypeDeserializer<Value<?>> {
       final String value = contents.toString();
       final Optional<ZonedDateTime> zonedDateTime = parseDate(value);
       return zonedDateTime
-          .map(ValueDeserializer::dateTimeValueOf)
+          .map(ValueDeserializer::timeStampValueOf)
           .orElseGet(() ->
               StringValue.newBuilder(value)
                   .setExcludeFromIndexes(value.getBytes().length > 1500)
                   .build());
     } else if (ZonedDateTime.class.isAssignableFrom(clazz)) {
-      final ZonedDateTime dateTime = cast(contents);
-      return DateTimeValue.of(DateTime.copyFrom(Date.from(dateTime.toInstant())));
+      return TimestampValue.of(Timestamp.of((Date.from(cast(contents)))));
     } else if (Instant.class.isAssignableFrom(clazz)) {
-      return DateTimeValue.of(DateTime.copyFrom(Date.from(cast(contents))));
+      return TimestampValue.of(Timestamp.of((Date.from(cast(contents)))));
     } else if (List.class.isAssignableFrom(clazz)) {
       final List<Object> rawList = cast(contents);
       return ListValue.of(rawList.stream()

--- a/src/main/java/com/bobkevic/jackson/datatype/serializers/DatastoreSerializers.java
+++ b/src/main/java/com/bobkevic/jackson/datatype/serializers/DatastoreSerializers.java
@@ -28,8 +28,8 @@ import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.Serializers;
 import com.fasterxml.jackson.databind.type.ReferenceType;
+import com.google.cloud.Timestamp;
 import com.google.cloud.datastore.Blob;
-import com.google.cloud.datastore.DateTime;
 import com.google.cloud.datastore.FullEntity;
 import com.google.cloud.datastore.Value;
 
@@ -57,8 +57,8 @@ public final class DatastoreSerializers extends Serializers.Base {
     final Class<?> rawClass = type.getRawClass();
     if (FullEntity.class.isAssignableFrom(rawClass)) {
       return FullEntitySerializer.INSTANCE;
-    } else if (DateTime.class.isAssignableFrom(rawClass)) {
-      return DateTimeSerializer.INSTANCE;
+    } else if (Timestamp.class.isAssignableFrom(rawClass)) {
+      return TimeStampSerializer.INSTANCE;
     } else if (Blob.class.isAssignableFrom(rawClass)) {
       return BlobSerializer.INSTANCE;
     }

--- a/src/main/java/com/bobkevic/jackson/datatype/serializers/FullEntitySerializer.java
+++ b/src/main/java/com/bobkevic/jackson/datatype/serializers/FullEntitySerializer.java
@@ -37,7 +37,7 @@ class FullEntitySerializer extends JsonSerializer<FullEntity> {
   public void serialize(final FullEntity value,
                         final JsonGenerator gen,
                         final SerializerProvider provider)
-      throws IOException, JsonProcessingException {
+      throws IOException {
     if (Objects.nonNull(value)) {
       gen.writeStartObject();
       for (final Object name : value.getNames()) {

--- a/src/main/java/com/bobkevic/jackson/datatype/serializers/TimeStampSerializer.java
+++ b/src/main/java/com/bobkevic/jackson/datatype/serializers/TimeStampSerializer.java
@@ -23,22 +23,24 @@ package com.bobkevic.jackson.datatype.serializers;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.google.cloud.datastore.DateTime;
+import com.google.cloud.Timestamp;
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Objects;
 
-class DateTimeSerializer extends JsonSerializer<DateTime> {
+class TimeStampSerializer extends JsonSerializer<Timestamp> {
 
-  static final DateTimeSerializer INSTANCE = new DateTimeSerializer();
+  static final TimeStampSerializer INSTANCE = new TimeStampSerializer();
 
   @Override
-  public void serialize(final DateTime value,
+  public void serialize(final Timestamp value,
                         final JsonGenerator gen,
                         final SerializerProvider provider)
       throws IOException {
     if (Objects.nonNull(value)) {
-      provider.findValueSerializer(Date.class).serialize(value.toDate(), gen, provider);
+      provider
+          .findValueSerializer(Instant.class)
+          .serialize(value.toSqlTimestamp().toInstant(), gen, provider);
     } else {
       gen.writeNull();
     }

--- a/src/test/java/com/bobkevic/jackson/datatype/deserializers/TimeStampValueDeserializerTest.java
+++ b/src/test/java/com/bobkevic/jackson/datatype/deserializers/TimeStampValueDeserializerTest.java
@@ -20,25 +20,24 @@ package com.bobkevic.jackson.datatype.deserializers;
  * #L%
  */
 
+import static com.bobkevic.jackson.datatype.Caster.cast;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.bobkevic.jackson.datatype.DatastoreModule;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.google.cloud.datastore.DateTimeValue;
 import com.google.cloud.datastore.FullEntity;
+import com.google.cloud.datastore.TimestampValue;
 import com.google.cloud.datastore.Value;
 import java.io.IOException;
 import java.time.ZonedDateTime;
-import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DateTimeValueDeserializerTest {
+public class TimeStampValueDeserializerTest {
 
   private ObjectMapper json;
 
@@ -54,9 +53,9 @@ public class DateTimeValueDeserializerTest {
         "{\"test-key-1\": \"2000-01-01T12:00Z\", \"test-key-2\": \"2000-01-01T12:01Z\"}";
     final FullEntity fullEntity = json.readValue(fixutre, FullEntity.class);
 
-    assertThat(fullEntity.getDateTime("test-key-1").toDate().toInstant(),
+    assertThat(fullEntity.getTimestamp("test-key-1").toSqlTimestamp().toInstant(),
         equalTo(ZonedDateTime.parse("2000-01-01T12:00Z").toInstant()));
-    assertThat(fullEntity.getDateTime("test-key-2").toDate().toInstant(),
+    assertThat(fullEntity.getTimestamp("test-key-2").toSqlTimestamp().toInstant(),
         equalTo(ZonedDateTime.parse("2000-01-01T12:01Z").toInstant()));
   }
 
@@ -68,12 +67,12 @@ public class DateTimeValueDeserializerTest {
         json.getTypeFactory().constructMapType(Map.class, String.class, Value.class);
     final Map<String, Value<?>> valueMap = json.readValue(fixutre, mapType);
 
-    final DateTimeValue dateTimeValue1 = (DateTimeValue) valueMap.get("test-key-1");
-    final DateTimeValue dateTimeValue2 = (DateTimeValue) valueMap.get("test-key-2");
+    final TimestampValue dateTimeValue1 = cast(valueMap.get("test-key-1"));
+    final TimestampValue dateTimeValue2 = cast(valueMap.get("test-key-2"));
 
-    assertThat(dateTimeValue1.get().toDate().toInstant(),
+    assertThat(dateTimeValue1.get().toSqlTimestamp().toInstant(),
         equalTo(ZonedDateTime.parse("2000-01-01T12:00Z").toInstant()));
-    assertThat(dateTimeValue2.get().toDate().toInstant(),
+    assertThat(dateTimeValue2.get().toSqlTimestamp().toInstant(),
         equalTo(ZonedDateTime.parse("2000-01-01T12:01Z").toInstant()));
   }
 

--- a/src/test/java/com/bobkevic/jackson/datatype/serializers/ValueSerializerTest.java
+++ b/src/test/java/com/bobkevic/jackson/datatype/serializers/ValueSerializerTest.java
@@ -25,14 +25,15 @@ import static org.junit.Assert.assertThat;
 
 import com.bobkevic.jackson.datatype.DatastoreModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.cloud.Timestamp;
 import com.google.cloud.datastore.Blob;
 import com.google.cloud.datastore.BlobValue;
 import com.google.cloud.datastore.BooleanValue;
-import com.google.cloud.datastore.DateTime;
-import com.google.cloud.datastore.DateTimeValue;
 import com.google.cloud.datastore.EntityValue;
 import com.google.cloud.datastore.FullEntity;
 import com.google.cloud.datastore.StringValue;
+import com.google.cloud.datastore.TimestampValue;
 import com.google.cloud.datastore.Value;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -49,7 +50,9 @@ public class ValueSerializerTest {
 
   @Before
   public void setUp() {
-    json = new ObjectMapper().registerModule(new DatastoreModule());
+    json = new ObjectMapper()
+        .registerModule(new DatastoreModule())
+        .registerModule(new JavaTimeModule());
   }
 
   @Test
@@ -59,7 +62,7 @@ public class ValueSerializerTest {
     final String testArrayKey = "test-array";
     final String testBlobKey = "blob-check-key";
     final List<? extends Value<?>> valueList = ImmutableList.<Value<?>>builder()
-        .add(DateTimeValue.of(DateTime.copyFrom(Date.from(Instant.parse("1970-01-01T00:00:01Z")))))
+        .add(TimestampValue.of(Timestamp.of((Date.from(Instant.parse("1970-01-01T00:00:01Z"))))))
         .add(StringValue.of("string-element1"))
         .add(BooleanValue.of(true))
         .add(EntityValue
@@ -76,7 +79,7 @@ public class ValueSerializerTest {
 
     assertThat(testValueString,
         is("{\"" + testBlobKey + "\":\"AQID\",\"" + testArrayKey
-           + "\":[1000,\"string-element1\",true,{\"embeded-key\":\"because-i-can\"}],\""
+           + "\":[1.000000000,\"string-element1\",true,{\"embeded-key\":\"because-i-can\"}],\""
            + testKey + "\":\"" + testValue + "\"}"));
   }
 


### PR DESCRIPTION
This pull request bumps google datastore to latest stable version and hence changes DateTimeValue to TimestampValue as the other one is deprecated and no longer provided. I don't know if we need to use RawValue.class to serialize the old data. But this supports the new classes.

It also kills off the unneeded guava dependency and adds a method to auto cast classes as java knows the type of the receiver method we can auto infer it at runtime and cast it.